### PR TITLE
Bump version in library metadata to 0.6

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Animation Tools
-version=0.5
+version=0.6
 author=Nick Puckett <info@puckettrand.com>
 maintainer=Nick Puckett <info@puckettrand.com>
 sentence=Simplifies creating behaviours for Servos and LEDs


### PR DESCRIPTION
In order to allow the library to be added to Library Manager (https://github.com/arduino/library-registry/pull/2057), a restructuring of the repository was done (https://github.com/npuckett/arduinoAnimation/pull/1). A new release of the library must now be made to distribute a valid version of the library.

In preparation for the release, the `version` value in [the `library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) must be updated.